### PR TITLE
Add Support for Setting a different Layout Manager on RecyclerKoletonView

### DIFF
--- a/koleton-base/src/main/kotlin/koleton/MainSkeletonLoader.kt
+++ b/koleton-base/src/main/kotlin/koleton/MainSkeletonLoader.kt
@@ -123,7 +123,8 @@ internal class MainSkeletonLoader(
                 shimmer = shimmer ?: defaults.shimmer,
                 lineSpacing = lineSpacing ?: defaults.lineSpacing,
                 itemLayout = itemLayoutResId,
-                itemCount = itemCount ?: defaults.itemCount
+                itemCount = itemCount ?: defaults.itemCount,
+                layoutManager = layoutManager
             )
             target.view.generateRecyclerKoletonView(attributes)
         } else {

--- a/koleton-base/src/main/kotlin/koleton/custom/Attributes.kt
+++ b/koleton-base/src/main/kotlin/koleton/custom/Attributes.kt
@@ -23,7 +23,8 @@ data class RecyclerViewAttributes(
     override val shimmer: Shimmer,
     override val lineSpacing: Float,
     @LayoutRes val itemLayout: Int,
-    val itemCount: Int
+    val itemCount: Int,
+    val layoutManager: RecyclerView.LayoutManager?
 ) : Attributes()
 
 data class SimpleViewAttributes(

--- a/koleton-base/src/main/kotlin/koleton/custom/RecyclerKoletonView.kt
+++ b/koleton-base/src/main/kotlin/koleton/custom/RecyclerKoletonView.kt
@@ -17,24 +17,34 @@ internal class RecyclerKoletonView @JvmOverloads constructor(
 
     private var adapter = attributes?.view?.adapter
 
+    private var originalLayoutManager = attributes?.view?.layoutManager
+
     private var skeletonAdapter: KoletonAdapter? = null
 
     override fun hideSkeleton() {
         isSkeletonShown = false
         hideShimmer()
-        attributes?.view?.adapter = adapter
+        attributes?.run {
+            view.adapter = adapter
+            view.layoutManager = originalLayoutManager
+        }
     }
 
     override fun showSkeleton() {
         isSkeletonShown = true
-        attributes?.view?.adapter = skeletonAdapter
+        attributes?.run {
+            view.adapter = skeletonAdapter
+            view.layoutManager = layoutManager
+        }
     }
 
     override fun applyAttributes() {
         attributes?.run {
             adapter = view.adapter
-            if (!isShimmerEnabled) hideShimmer() else setShimmer(shimmer)
             skeletonAdapter = KoletonAdapter(itemLayout, itemCount, this)
+            originalLayoutManager = view.layoutManager
+
+            if (!isShimmerEnabled) hideShimmer() else setShimmer(shimmer)
             if (isSkeletonShown) {
                 showSkeleton()
             }

--- a/koleton-base/src/main/kotlin/koleton/custom/RecyclerKoletonView.kt
+++ b/koleton-base/src/main/kotlin/koleton/custom/RecyclerKoletonView.kt
@@ -26,7 +26,7 @@ internal class RecyclerKoletonView @JvmOverloads constructor(
         hideShimmer()
         attributes?.run {
             view.adapter = adapter
-            view.layoutManager = originalLayoutManager
+            originalLayoutManager?.let { view.layoutManager = it }
         }
     }
 
@@ -34,7 +34,7 @@ internal class RecyclerKoletonView @JvmOverloads constructor(
         isSkeletonShown = true
         attributes?.run {
             view.adapter = skeletonAdapter
-            view.layoutManager = layoutManager
+            layoutManager?.let { view.layoutManager = it }
         }
     }
 
@@ -42,7 +42,7 @@ internal class RecyclerKoletonView @JvmOverloads constructor(
         attributes?.run {
             adapter = view.adapter
             skeletonAdapter = KoletonAdapter(itemLayout, itemCount, this)
-            originalLayoutManager = view.layoutManager
+            layoutManager?.let { originalLayoutManager = view.layoutManager }
 
             if (!isShimmerEnabled) hideShimmer() else setShimmer(shimmer)
             if (isSkeletonShown) {

--- a/koleton-base/src/main/kotlin/koleton/skeleton/Skeleton.kt
+++ b/koleton-base/src/main/kotlin/koleton/skeleton/Skeleton.kt
@@ -156,7 +156,8 @@ class RecyclerViewSkeleton internal constructor(
     @LayoutRes internal val itemLayoutResId: Int,
     internal val itemCount: Int?,
     override val shimmer: Shimmer?,
-    override val lineSpacing: Float?
+    override val lineSpacing: Float?,
+    internal val layoutManager: RecyclerView.LayoutManager?
 ) : Skeleton() {
 
     /** Create a new [Builder] instance using this as a base. */
@@ -170,12 +171,14 @@ class RecyclerViewSkeleton internal constructor(
         @LayoutRes
         private var itemLayoutResId: Int
         private var itemCount: Int?
+        private var layoutManager: RecyclerView.LayoutManager?
 
         constructor(context: Context, @LayoutRes itemLayout: Int) : super(context) {
             target = null
             lifecycle = null
             itemLayoutResId = itemLayout
             itemCount = null
+            layoutManager = null
         }
 
         @JvmOverloads
@@ -187,6 +190,7 @@ class RecyclerViewSkeleton internal constructor(
             lifecycle = skeleton.lifecycle
             itemLayoutResId = skeleton.itemLayoutResId
             itemCount = skeleton.itemCount
+            layoutManager = skeleton.layoutManager
         }
 
         /**
@@ -238,7 +242,8 @@ class RecyclerViewSkeleton internal constructor(
                 itemLayoutResId,
                 itemCount,
                 shimmer,
-                lineSpacing
+                lineSpacing,
+                layoutManager
             )
         }
     }


### PR DESCRIPTION
This change adds support for setting a `RecyclerView.LayoutManager` for the use by `RecyclerKoletonView`. This will allow skeleton layouts to be rendered for alternate `LayoutManager`s, like `GridLayoutManager` and `StaggeredGridLayoutManager`.

Note that this PR may need some additional work before it will be accepted. I wanted to pitch the initial idea before going through the effort of updating examples and documentation.